### PR TITLE
build error fix

### DIFF
--- a/rpmbuild.go
+++ b/rpmbuild.go
@@ -18,22 +18,22 @@ type RpmBuildFlag uint32
 
 const (
 	RPMBUILD_NONE          = RpmBuildFlag(C.RPMBUILD_NONE)
-	RPMBUILD_PREP          = RpmBuildFlag(C.RPMBUILD_PREP)          // execute %prep
-	RPMBUILD_BUILD         = RpmBuildFlag(C.RPMBUILD_BUILD)         // execute %build
-	RPMBUILD_INSTALL       = RpmBuildFlag(C.RPMBUILD_INSTALL)       // execute install
-	RPMBUILD_CHECK         = RpmBuildFlag(C.RPMBUILD_CHECK)        // execute %check
-	RPMBUILD_CLEAN         = RpmBuildFlag(C.RPMBUILD_CLEAN)         // execute %clean
-	RPMBUILD_FILECHECK     = RpmBuildFlag(C.RPMBUILD_FILECHECK)     // check %files manifest
-	RPMBUILD_PACKAGESOURCE = RpmBuildFlag(C.RPMBUILD_PACKAGESOURCE) // create source package
-	RPMBUILD_PACKAGEBINARY = RpmBuildFlag(C.RPMBUILD_PACKAGEBINARY) // create binary package(s)
-	RPMBUILD_RMSOURCE      = RpmBuildFlag(C.RPMBUILD_RMSOURCE)      // remove source(s) and patch(s)
-	RPMBUILD_RMBUILD       = RpmBuildFlag(C.RPMBUILD_RMBUILD)       // remove build sub-tree
-	RPMBUILD_STRINGBUF     = RpmBuildFlag(C.RPMBUILD_STRINGBUF)     // internal use only
-	RPMBUILD_RMSPEC        = RpmBuildFlag(C.RPMBUILD_RMSPEC)        // remove spec file
-	RPMBUILD_FILE_FILE     = RpmBuildFlag(C.RPMBUILD_FILE_FILE)     // rpmSpecPkgGetSection: %files -f
-	RPMBUILD_FILE_LIST     = RpmBuildFlag(C.RPMBUILD_FILE_LIST)     // rpmSpecPkgGetSection: %files
-	RPMBUILD_POLICY        = RpmBuildFlag(C.RPMBUILD_POLICY)        // rpmSpecPkgGetSection: %policy
-	RPMBUILD_NOBUILD       = RpmBuildFlag(C.RPMBUILD_NOBUILD)       // don't execute or package
+	RPMBUILD_PREP          = RpmBuildFlag(C.RPMBUILD_PREP)                // execute %prep
+	RPMBUILD_BUILD         = RpmBuildFlag(C.RPMBUILD_BUILD)               // execute %build
+	RPMBUILD_INSTALL       = RpmBuildFlag(C.RPMBUILD_INSTALL)             // execute install
+	RPMBUILD_CHECK         = RpmBuildFlag(C.RPMBUILD_CHECK)               // execute %check
+	RPMBUILD_CLEAN         = RpmBuildFlag(C.RPMBUILD_CLEAN)               // execute %clean
+	RPMBUILD_FILECHECK     = RpmBuildFlag(C.RPMBUILD_FILECHECK)           // check %files manifest
+	RPMBUILD_PACKAGESOURCE = RpmBuildFlag(C.RPMBUILD_PACKAGESOURCE)       // create source package
+	RPMBUILD_PACKAGEBINARY = RpmBuildFlag(C.RPMBUILD_PACKAGEBINARY)       // create binary package(s)
+	RPMBUILD_RMSOURCE      = RpmBuildFlag(C.RPMBUILD_RMSOURCE)            // remove source(s) and patch(s)
+	RPMBUILD_RMBUILD       = RpmBuildFlag(C.RPMBUILD_RMBUILD)             // remove build sub-tree
+	RPMBUILD_STRINGBUF     = RpmBuildFlag(C.RPMBUILD_STRINGBUF)           // internal use only
+	RPMBUILD_RMSPEC        = RpmBuildFlag(C.RPMBUILD_RMSPEC)              // remove spec file
+	RPMBUILD_FILE_FILE     = RpmBuildFlag(C.RPMBUILD_FILE_FILE)           // rpmSpecPkgGetSection: %files -f
+	RPMBUILD_FILE_LIST     = RpmBuildFlag(C.RPMBUILD_FILE_LIST)           // rpmSpecPkgGetSection: %files
+	RPMBUILD_POLICY        = RpmBuildFlag(C.RPMBUILD_POLICY)              // rpmSpecPkgGetSection: %policy
+	RPMBUILD_NOBUILD       = RpmBuildFlag(C.RPMBUILD_NOBUILD + (1 << 32)) // don't execute or package
 )
 
 type Spec struct {

--- a/rpmbuild.go
+++ b/rpmbuild.go
@@ -18,23 +18,24 @@ type RpmBuildFlag uint32
 
 const (
 	RPMBUILD_NONE          = RpmBuildFlag(C.RPMBUILD_NONE)
-	RPMBUILD_PREP          = RpmBuildFlag(C.RPMBUILD_PREP)                // execute %prep
-	RPMBUILD_BUILD         = RpmBuildFlag(C.RPMBUILD_BUILD)               // execute %build
-	RPMBUILD_INSTALL       = RpmBuildFlag(C.RPMBUILD_INSTALL)             // execute install
-	RPMBUILD_CHECK         = RpmBuildFlag(C.RPMBUILD_CHECK)               // execute %check
-	RPMBUILD_CLEAN         = RpmBuildFlag(C.RPMBUILD_CLEAN)               // execute %clean
-	RPMBUILD_FILECHECK     = RpmBuildFlag(C.RPMBUILD_FILECHECK)           // check %files manifest
-	RPMBUILD_PACKAGESOURCE = RpmBuildFlag(C.RPMBUILD_PACKAGESOURCE)       // create source package
-	RPMBUILD_PACKAGEBINARY = RpmBuildFlag(C.RPMBUILD_PACKAGEBINARY)       // create binary package(s)
-	RPMBUILD_RMSOURCE      = RpmBuildFlag(C.RPMBUILD_RMSOURCE)            // remove source(s) and patch(s)
-	RPMBUILD_RMBUILD       = RpmBuildFlag(C.RPMBUILD_RMBUILD)             // remove build sub-tree
-	RPMBUILD_STRINGBUF     = RpmBuildFlag(C.RPMBUILD_STRINGBUF)           // internal use only
-	RPMBUILD_RMSPEC        = RpmBuildFlag(C.RPMBUILD_RMSPEC)              // remove spec file
-	RPMBUILD_FILE_FILE     = RpmBuildFlag(C.RPMBUILD_FILE_FILE)           // rpmSpecPkgGetSection: %files -f
-	RPMBUILD_FILE_LIST     = RpmBuildFlag(C.RPMBUILD_FILE_LIST)           // rpmSpecPkgGetSection: %files
-	RPMBUILD_POLICY        = RpmBuildFlag(C.RPMBUILD_POLICY)              // rpmSpecPkgGetSection: %policy
-	RPMBUILD_NOBUILD       = RpmBuildFlag(C.RPMBUILD_NOBUILD + (1 << 32)) // don't execute or package
+	RPMBUILD_PREP          = RpmBuildFlag(C.RPMBUILD_PREP)          // execute %prep
+	RPMBUILD_BUILD         = RpmBuildFlag(C.RPMBUILD_BUILD)         // execute %build
+	RPMBUILD_INSTALL       = RpmBuildFlag(C.RPMBUILD_INSTALL)       // execute install
+	RPMBUILD_CHECK         = RpmBuildFlag(C.RPMBUILD_CHECK)         // execute %check
+	RPMBUILD_CLEAN         = RpmBuildFlag(C.RPMBUILD_CLEAN)         // execute %clean
+	RPMBUILD_FILECHECK     = RpmBuildFlag(C.RPMBUILD_FILECHECK)     // check %files manifest
+	RPMBUILD_PACKAGESOURCE = RpmBuildFlag(C.RPMBUILD_PACKAGESOURCE) // create source package
+	RPMBUILD_PACKAGEBINARY = RpmBuildFlag(C.RPMBUILD_PACKAGEBINARY) // create binary package(s)
+	RPMBUILD_RMSOURCE      = RpmBuildFlag(C.RPMBUILD_RMSOURCE)      // remove source(s) and patch(s)
+	RPMBUILD_RMBUILD       = RpmBuildFlag(C.RPMBUILD_RMBUILD)       // remove build sub-tree
+	RPMBUILD_STRINGBUF     = RpmBuildFlag(C.RPMBUILD_STRINGBUF)     // internal use only
+	RPMBUILD_RMSPEC        = RpmBuildFlag(C.RPMBUILD_RMSPEC)        // remove spec file
+	RPMBUILD_FILE_FILE     = RpmBuildFlag(C.RPMBUILD_FILE_FILE)     // rpmSpecPkgGetSection: %files -f
+	RPMBUILD_FILE_LIST     = RpmBuildFlag(C.RPMBUILD_FILE_LIST)     // rpmSpecPkgGetSection: %files
+	RPMBUILD_POLICY        = RpmBuildFlag(C.RPMBUILD_POLICY)        // rpmSpecPkgGetSection: %policy
 )
+
+var RPMBUILD_NOBUILD = sanitizeRpmbuilNobuild() // don't execute or package
 
 type Spec struct {
 	rpmSpec C.rpmSpec
@@ -58,4 +59,12 @@ func (spec *Spec) Free() {
 func (spec *Spec) SourceHeader() *Header {
 	cHeader := C.rpmSpecSourceHeader(spec.rpmSpec)
 	return &Header{c_header: cHeader}
+}
+
+func sanitizeRpmbuilNobuild() RpmBuildFlag {
+	rpmbuildNobuild := C.RPMBUILD_NOBUILD
+	if rpmbuildNobuild < 0 {
+		return RpmBuildFlag(rpmbuildNobuild + (1 << 32))
+	}
+	return RpmBuildFlag(rpmbuildNobuild)
 }

--- a/rpmtag.go
+++ b/rpmtag.go
@@ -10,6 +10,11 @@ package rpm
 
 // #cgo LDFLAGS: -lrpm
 // #include <rpm/rpmlib.h>
+// #ifndef RPMTAG_HDRID
+// #define RPMTAG_HDRID 	RPMTAG_SHA1HEADER
+// #define RPMTAG_PKGID 	RPMTAG_SIGMD5
+// #define RPMTAG_SOURCEPKGID	RPMTAG_SOURCESIGMD5
+// #endif
 import "C"
 
 
@@ -154,6 +159,7 @@ const (
 	RPMTAG_FILEDEPENDSN      = RpmTag(C.RPMTAG_FILEDEPENDSN)      // i[]
 	RPMTAG_DEPENDSDICT       = RpmTag(C.RPMTAG_DEPENDSDICT)       // i[]
 	RPMTAG_SOURCEPKGID       = RpmTag(C.RPMTAG_SOURCEPKGID)       // x
+	RPMTAG_SOURCESIGMD5      = RpmTag(C.RPMTAG_SOURCEPKGID)       // x
 	RPMTAG_FSCONTEXTS        = RpmTag(C.RPMTAG_FSCONTEXTS)        // s[] extension
 	RPMTAG_RECONTEXTS        = RpmTag(C.RPMTAG_RECONTEXTS)        // s[] extension
 	// s[] selinux *.te policy file


### PR DESCRIPTION
fixing build error on go 1.15.14:

rpmbuild.go:36:39: constant -2147483648 overflows RpmBuildFlag